### PR TITLE
Add `jq` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
 FROM alpine:3.10
+
+RUN apk add --no-cache ca-certificates bash jq
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
`jq` is currently missing and this broke the action. Adding it via the Dockerfile makes it work again.