### PR TITLE
Use GITHUB_OUTPUT instead of set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@ PACKAGE_JSON_PATH="${1-.}"
 echo "Reading package.json from ${PACKAGE_JSON_PATH}/package.json"
 PACKAGE_VERSION=$(cat ${PACKAGE_JSON_PATH}/package.json | jq '.version' | tr -d '"')
 
-echo ::set-output name=current-version::$PACKAGE_VERSION
+echo "current-version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Change needed for set-output deprecation. More info at:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/